### PR TITLE
Improve cookies management

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -12,27 +12,15 @@ namespace App\Controller;
 use App\Service\WowWeek;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 
 class HomeController extends AbstractController
 {
-    public function __invoke(Request $request, WowWeek $wowWeek)
+    public function __invoke(WowWeek $wowWeek)
     {
-        $isNightMode = $_COOKIE['isNightMode'] ?? 'false';
-        $isNightMode = filter_var($isNightMode, FILTER_VALIDATE_BOOLEAN);
-
-        $hideAlertNightMode = !empty($_COOKIE['hideAlertNightMode']);
-
-        setcookie('hideAlertNightMode', 'true', time() + 60 * 60 * 24 * 30);
-
-        if ((new \DateTimeImmutable())  > new \DateTimeImmutable('2020-03-01')) {
-            $hideAlertNightMode = true;
-        }
-
         return $this->render('homepage.html.twig', [
             'wowaffixes' => $wowWeek,
-            'isNightMode' => $isNightMode,
-            'hideAlertNightMode' => $hideAlertNightMode,
         ]);
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -15,7 +15,7 @@
     <meta property="og:description" content="Check what is the current WoW Affixes rotation">
     {% block stylesheets %}{% endblock %}
 </head>
-<body class="{% if isNightMode %}darkmode{% endif %}">
+<body class="{% if app.request.cookies.getBoolean('isNightMode') %}darkmode{% endif %}">
 <nav class="navbar navbar-default {% if isNightMode %}navbar-inverse{% endif %} navbar-static-top">
     <div class="container-fluid">
         <div class="navbar-header">

--- a/templates/homepage.html.twig
+++ b/templates/homepage.html.twig
@@ -62,7 +62,4 @@
             </div>
         </div>
     </div>
-    {% if not hideAlertNightMode %}
-        <div class="alert alert-info col-sm-8 col-md-5 mygear">New Night Mode ! Switch to it in the menu ! :)</div>
-    {% endif %}
 {% endblock %}


### PR DESCRIPTION
My goal was to improve the cookie management by using the HttpFoundation Symfony component functionnality.

There was two cookies:

1. isNightMode
I removed the logic in the controller and access the cookie directly in the Twig base layout through the Symfony HttpFoundation Request.

2. hideAlertNightMode
I started to work on how to manage this one and then I realised that it was not needed anymore since the limit date for this functionnality has been reached (2020-03-01). So I removed the functionnality completely.
